### PR TITLE
ft(user redirect): Redirects users on actions performed

### DIFF
--- a/src/apps/Articles/actions/common/common.js
+++ b/src/apps/Articles/actions/common/common.js
@@ -1,0 +1,25 @@
+import { toast} from 'react-toastify';
+
+export function redirectUrl(url){
+    setTimeout(function(){ openWindow(url); }, 1000);
+}
+
+ export function openWindow(url){
+    window.location.replace(url);
+}
+
+export function toastNotification(type, message){
+    switch (type) {
+        case "success":
+        return toast.success(`🦄 ${message}`, { position: toast.POSITION.TOP_RIGHT, autoClose: 800 });
+
+         case "warn":
+        return toast.warn(`🦄 ${message}`, { position: toast.POSITION.TOP_RIGHT, autoClose: 800 });
+
+         case "error":
+        return toast.error(`🦄 ${message}`, { position: toast.POSITION.TOP_RIGHT, autoClose: 1200 });
+
+         default:
+        return toast("hello");
+    }
+}

--- a/src/apps/Articles/actions/common/common.test.js
+++ b/src/apps/Articles/actions/common/common.test.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import {mount} from 'enzyme';
+import { toast, ToastContainer } from 'react-toastify';
+import * as commonActions from './common';
+
+'use strict';
+
+jest.useFakeTimers();
+
+test('waits 1 second before ending the game', () => {
+
+  commonActions.redirectUrl('/the-url');
+
+  expect(setTimeout).toHaveBeenCalledTimes(1);
+  expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 1000);
+});
+
+
+test('test window open happened', () => {
+    window.location.replace = jest.fn();
+    commonActions.openWindow("http://some-url"); //The action
+    expect(window.location.replace).toHaveBeenCalled();
+    expect(window.location.replace).toBeCalledWith('http://some-url');
+});
+
+
+describe('Toast function tests', () => {
+
+    jest.useFakeTimers();
+
+    it('toast.isActive should return false until the container is mounted', () => {
+     const isActive = toast.isActive();
+     expect(isActive).toBe(false);
+   });
+
+    it('Should return all toast called true ', () => {
+     mount(<ToastContainer />);
+     const sc = commonActions.toastNotification("success", "Hello", 800);
+     const wr = commonActions.toastNotification("warn", "Hello", 800);
+     const er = commonActions.toastNotification("error", "Hello", 800);
+     const ot = commonActions.toastNotification("other", "Hello", 800);
+
+      jest.runAllTimers();
+     expect(toast.isActive(sc)).toBe(true);
+     expect(toast.isActive(wr)).toBe(true);
+     expect(toast.isActive(er)).toBe(true);
+     expect(toast.isActive(ot)).toBe(true);
+   });
+});

--- a/src/apps/Articles/actions/delete/_delete_actions.js
+++ b/src/apps/Articles/actions/delete/_delete_actions.js
@@ -1,14 +1,14 @@
 import axios from 'axios';
-import { toast } from 'react-toastify';
 import { read_cookie } from 'sfcookies';
+import {redirectUrl,toastNotification } from '../common/common';
 import {DELETING_ARTICLE, ERROR_DELETING_ARTICLE, DELETED_ARTICLE} from '../actionTypes';
 
 export const deleteArticle = (slug) =>dispatch=> {
 
     const token = read_cookie("token");
-    //dispatch(deletingArticle());
+    dispatch(deletingArticle(slug));
     let url = `https://ah-jumanji-staging.herokuapp.com/api/articles/${slug}/`;
-    return axios.delete(url, {
+    let Call =  axios.delete(url, {
         headers: {
             Accept: "application/json", //transfer type
             Authorization: `Token ${token}`
@@ -17,13 +17,14 @@ export const deleteArticle = (slug) =>dispatch=> {
         })
         .then((response) => {
             dispatch(deletedArticle(response.data));
-            toast.success(`🦄 ${slug} has been deleted`, { position: toast.POSITION.TOP_RIGHT, autoClose: 3500 });
+            toastNotification("success","Article Deleted");
+            redirectUrl(`/a/home${response.data.article.slug}`);
         })
         .catch((err) => {
             dispatch(deleteError(err));
-            toast.error('🦄 Could not delete that article!',{ position: toast.POSITION.TOP_RIGHT });
+            toastNotification("error","Could not delete that article!");
         });
-
+        return Call;
 };
 
 export function deletingArticle(data){
@@ -47,9 +48,9 @@ export function deletedArticle(data){
     };
 }
 
-export function deleteError(err){
+export function deleteError(){
     return{
         type: ERROR_DELETING_ARTICLE,
-        payload:err
+        payload:"Cannot delete"
     };
 }

--- a/src/apps/Articles/actions/delete/_delete_actions.test.js
+++ b/src/apps/Articles/actions/delete/_delete_actions.test.js
@@ -1,3 +1,7 @@
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import moxios from 'moxios';
+
 import * as delete_actions from './_delete_actions';
 import {DELETING_ARTICLE, ERROR_DELETING_ARTICLE, DELETED_ARTICLE} from '../actionTypes';
 
@@ -38,12 +42,41 @@ it('return state data when article delete is errored', () => {
     expect(delete_actions.deleteError(passed_payload)).toEqual(returnedData);
   });
 
-  //Testing async tests
-  describe("Test for the delete async function", ()=>{
-      it("Should return a fetched success slug",() => {
-          let deleteData = delete_actions.deleteArticle('this-is-string-963376');
-          deleteData().then(response => {
-              expect(response.data.articles.slug).toEqual("string-e678-963376");
-          });
+  const middlewares = [thunk];
+  const mockStore = configureMockStore(middlewares);
+
+  describe('getDelete actions', () => {
+
+    let  store = mockStore({});
+    beforeEach(function () {
+      moxios.install();
+    store = mockStore({ posts: {} });
+    });
+
+    afterEach(function () {
+      moxios.uninstall();
+    });
+
+    it('creates GET_POSTS_SUCCESS after successfuly fetching postse', () => {
+    let getPostsMock = {response: "This is the response"};
+      moxios.wait(() => {
+        const request = moxios.requests.mostRecent();
+        request.respondWith({
+          status: 200,
+          response: getPostsMock,
+        });
       });
+
+      const expectedActions = [
+        { type: DELETING_ARTICLE, payload:{deleted: "this is slug", deleting:true} },
+        { type: DELETED_ARTICLE, payload:{deleted: getPostsMock, posting: false, fetching: false}},
+        { type: ERROR_DELETING_ARTICLE, payload:"Cannot delete"},
+      ];
+
+
+      return store.dispatch(delete_actions.deleteArticle("this is slug")).then(() => {
+        // return of async actions
+        expect(store.getActions()).toEqual(expectedActions);
+      });
+    });
   });

--- a/src/apps/Articles/actions/fetch/_get_actions.js
+++ b/src/apps/Articles/actions/fetch/_get_actions.js
@@ -1,13 +1,13 @@
 import axios from 'axios';
-import { toast } from 'react-toastify';
 import { read_cookie } from 'sfcookies';
+import {toastNotification } from '../common/common';
 import { GOT_ARTICLE, ERROR_GETTING_ARTICLE} from '../actionTypes';
 
 export const getArticles = (slug) =>dispatch=> {
 
     const token = read_cookie("token");
       let url = `https://ah-jumanji-staging.herokuapp.com/api/articles/${slug}/`;
-      return axios.get(url, {
+      let fetch = axios.get(url, {
           headers: {
             Accept: "application/json",
             Authorization: `Token ${token}`
@@ -16,13 +16,12 @@ export const getArticles = (slug) =>dispatch=> {
         })
         .then((response) => {
           dispatch(gotArticle(response.data.articles));
-          toast.success(`🦄 ${response.data.articles.slug} has been fetched`, { position: toast.POSITION.TOP_RIGHT, autoClose: 3500 });
         })
         .catch((err) => {
             dispatch(getError(err));
-            toast.error('🦄 Could not get that article!',{ position: toast.POSITION.TOP_RIGHT });
+            toastNotification("error", "Could not get that article!");
         });
-
+    return fetch;
 };
 
 export function gotArticle(data){
@@ -36,9 +35,9 @@ export function gotArticle(data){
     };
 }
 
-export function getError(err){
+export function getError(){
     return{
         type: ERROR_GETTING_ARTICLE,
-        payload:err
+        payload: "Could not get that article"
     };
 }

--- a/src/apps/Articles/actions/fetch/_get_actions.test.js
+++ b/src/apps/Articles/actions/fetch/_get_actions.test.js
@@ -1,3 +1,7 @@
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import moxios from 'moxios';
+
 import * as get_actions from './_get_actions';
 import {GOT_ARTICLE, ERROR_GETTING_ARTICLE} from '../actionTypes';
 
@@ -18,20 +22,47 @@ it('return state data when article is fetched', () => {
 
 
 it('return state data when article fetching is errored', () => {
-    const passed_payload = "Cannot fetch";
+    const passed_payload = "Could not get that article";
     const returnedData = {
-        "payload": "Cannot fetch",
+        "payload": "Could not get that article",
         "type": ERROR_GETTING_ARTICLE
     };
     expect(get_actions.getError(passed_payload)).toEqual(returnedData);
   });
 
-//Testing async tests
-describe("Test for the fetch async function", ()=>{
-    it("Should return a fetched success slug",() => {
-        let fetchData = get_actions.getArticles('this-is-string-963376');
-        fetchData().then(response => {
-            expect(response.data.articles.slug).toEqual("string-e678-963376");
-        });
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
+
+describe('getDelete actions', () => {
+
+  let  store = mockStore({});
+  beforeEach(function () {
+    moxios.install();
+  store = mockStore({ posts: {} });
+  });
+
+  afterEach(function () {
+    moxios.uninstall();
+  });
+
+  it('creates GET_POSTS_SUCCESS after successfuly fetching postse', () => {
+  let getPostsMock = {articles: "this is slug"};
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.respondWith({
+        status: 200,
+        response: getPostsMock,
+      });
     });
+
+    const expectedActions = [
+        { type: GOT_ARTICLE, payload:{read_article: "this is slug", posting: false, fetching: false }},
+        ];
+
+
+    return store.dispatch(get_actions.getArticles("this is slug")).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
 });

--- a/src/apps/Articles/actions/post/_post_actions.js
+++ b/src/apps/Articles/actions/post/_post_actions.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
-import { toast } from 'react-toastify';
 import { read_cookie } from 'sfcookies';
+import {redirectUrl, toastNotification } from '../common/common';
 import {POSTING_ARTICLE, POSTED_ARTICLE, ERROR_POSTING_ARTICLE} from '../actionTypes';
 
 export const postArticle = (body) =>dispatch=> {
@@ -10,7 +10,7 @@ export const postArticle = (body) =>dispatch=> {
         "body": body,"tagList": "[default]"};
 
       if(article_data.title === ""){
-        toast.warn('🦄 You need a title',{ position: toast.POSITION.TOP_RIGHT, autoClose: 3500 });
+        toastNotification("warn", "You need a title");
       }else{
         //dispatch(postingArticle(article_data));
         let url = "https://ah-jumanji-staging.herokuapp.com/api/articles/";
@@ -22,10 +22,11 @@ export const postArticle = (body) =>dispatch=> {
             }).then((response) => {
             //Posting success
             dispatch(postedArticle(response.data));
-            toast.success(`🦄 ${response.data.article.slug} has been posted`, { position: toast.POSITION.TOP_RIGHT, autoClose: 3500 });
+            toastNotification("success", "Article Posted");
+            redirectUrl(`/a/view_article/${response.data.article.slug}`);
           }).catch((err) => {
               dispatch(postingError(err));
-              toast.error('🦄 Could not post that article!',{ position: toast.POSITION.TOP_RIGHT });
+              toastNotification("success", "Could not post that article!");
           });
       }
 };
@@ -65,9 +66,9 @@ export function postedArticle(data){
     };
 }
 
-export function postingError(err){
+export function postingError(){
     return{
         type: ERROR_POSTING_ARTICLE,
-        payload:err
+        payload:"Could not post"
     };
 }

--- a/src/apps/Articles/actions/post/_post_actions.test.js
+++ b/src/apps/Articles/actions/post/_post_actions.test.js
@@ -1,11 +1,10 @@
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
+import moxios from 'moxios';
+
 import * as post_actions from './_post_actions';
 import {POSTING_ARTICLE, POSTED_ARTICLE, ERROR_POSTING_ARTICLE} from '../actionTypes';
 
-
-const middlewares = [thunk];
-const mockStore = configureMockStore(middlewares);
 
 it('return state data when article is being posted', () => {
 
@@ -43,7 +42,7 @@ it('return state data when article is posted', () => {
 it('return state data when article posting is errored', () => {
     const passed_payload = "Cannot post";
     const returnedData = {
-        "payload": "Cannot post",
+        "payload": "Could not post",
         "type": ERROR_POSTING_ARTICLE
     };
     expect(post_actions.postingError(passed_payload)).toEqual(returnedData);
@@ -60,3 +59,43 @@ describe("Test for the posting async function", ()=>{
     });
 
 });
+
+
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
+
+describe('getDelete actions', () => {
+
+  let  store = mockStore({});
+  beforeEach(function () {
+    moxios.install();
+    store = mockStore({ posts: {} });
+  });
+
+  afterEach(function () {
+    moxios.uninstall();
+  });
+
+  it('creates GET_POSTS_SUCCESS after successfuly fetching postse', () => {
+  let getPostsMock = {articles: "this is slug"};
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.respondWith({
+        status: 200,
+        response: getPostsMock,
+      });
+    });
+
+    const expectedActions = [
+        { type: POSTED_ARTICLE, payload:{data: getPostsMock, posting: false, fetching: false }},
+        { type: ERROR_POSTING_ARTICLE, payload:"Could not post" },
+        ];
+
+
+    return store.dispatch(post_actions.postArticle("this is slug")).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+});
+

--- a/src/apps/Articles/actions/update/_update_actions.js
+++ b/src/apps/Articles/actions/update/_update_actions.js
@@ -1,32 +1,33 @@
 import axios from 'axios';
-import { toast } from 'react-toastify';
 import { read_cookie } from 'sfcookies';
+import {redirectUrl, toastNotification } from '../common/common';
 import {UPDATING_ARTICLE, UPDATED_ARTICLE, UPDATED_ERROR,UPDATING_CURRENT} from '../actionTypes';
 import {articleCreator} from '../post/_post_actions';
 
 export const updateArticle = (body,slug) =>dispatch=> {
     const token = read_cookie("token");
-    let article_data = {
+    let updated_data = {
         "title": articleCreator(body,0), //Get the title
         "description": articleCreator(body,0), // Get first paragraph
         "body": body,
         "tagList": "[default]"
       };
-      if(article_data.title === ""){
-        toast.warn('🦄 You need a title',{ position: toast.POSITION.TOP_RIGHT, autoClose: 3500 });
+      if(updated_data.title === ""){
+        toastNotification("warn", "You need a title");
       }else{
-        //dispatch(updatingArticle(article_data));
-        let url = `https://ah-jumanji-staging.herokuapp.com/api/articles/${slug}/`;
-        return axios.put(url, article_data, {
+        let updateUrl = `https://ah-jumanji-staging.herokuapp.com/api/articles/${slug}/`;
+        let TheCall = axios.put(updateUrl, updated_data, {
             headers: {Accept: "application/json",Authorization: `Token ${token}`},crossDomain: true
           }).then((response) => {
             //Update successfull
             dispatch(updatedArticle(response.data));
-            toast.success(`🦄 ${response.data.article.slug} has been updated`, { position: toast.POSITION.TOP_RIGHT, autoClose: 3500 });
+            toastNotification("success", "Article Updated");
+            redirectUrl(`/a/view_article/${response.data.article.slug}`);
           }).catch((err) => {
               dispatch(updateError(err));
-              toast.error('🦄 Could not update that article!',{ position: toast.POSITION.TOP_RIGHT });
+              toastNotification("error", "Could not update that article!");
           });
+        return TheCall;
       }
 };
 
@@ -46,16 +47,16 @@ export function updatedArticle(data){
         type: UPDATED_ARTICLE,
         payload:{
             data,
-            posting: false,
+            updating: false,
             fetching: false
         }
     };
 }
 
-export function updateError(err){
+export function updateError(){
     return{
         type: UPDATED_ERROR,
-        payload:err
+        payload: "Could not update"
     };
 }
 

--- a/src/apps/Articles/actions/update/_update_actions.test.js
+++ b/src/apps/Articles/actions/update/_update_actions.test.js
@@ -1,3 +1,7 @@
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import moxios from 'moxios';
+
 import * as update_actions from './_update_actions';
 import {
   UPDATING_ARTICLE,
@@ -33,7 +37,7 @@ it('return state data when article is posted', () => {
     type: UPDATED_ARTICLE,
     payload: {
       data,
-      posting: false,
+      updating: false,
       fetching: false
     }
   };
@@ -43,9 +47,9 @@ it('return state data when article is posted', () => {
 
 
 it('return state data when article updating is errored', () => {
-  const passed_payload = "Cannot update";
+  const passed_payload = "Could not update";
   const returnedData = {
-    "payload": "Cannot update",
+    "payload": "Could not update",
     "type": UPDATED_ERROR
   };
   expect(update_actions.updateError(passed_payload)).toEqual(returnedData);
@@ -77,3 +81,44 @@ describe("Test for the updating async function", ()=>{
   });
 
 });
+
+
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
+
+describe('getDelete actions', () => {
+
+  let  store = mockStore({});
+  beforeEach(function () {
+    moxios.install();
+    store = mockStore({ posts: {} });
+  });
+
+  afterEach(function () {
+    moxios.uninstall();
+  });
+
+  it('creates GET_POSTS_SUCCESS after successfuly fetching postse', () => {
+  let getPostsMock = {articles: "this is article data"};
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.respondWith({
+        status: 200,
+        response: getPostsMock,
+      });
+    });
+
+    const expectedActions = [
+        //{ type: UPDATING_ARTICLE, payload:{data: getPostsMock, updating:true, fetching: false }},
+        { type: UPDATED_ARTICLE, payload:{data: getPostsMock, updating:false, fetching: false }},
+        { type: UPDATED_ERROR, payload:"Could not update" },
+        ];
+
+
+    return store.dispatch(update_actions.updateArticle("<p>This is the body</p><p>I love body!</p>","this is slug")).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+});
+

--- a/src/apps/Bookmarks/components/__snapshots__/Bookmarks.test.js.snap
+++ b/src/apps/Bookmarks/components/__snapshots__/Bookmarks.test.js.snap
@@ -44,7 +44,7 @@ exports[`<Bookmarks /> should match the snapshot 1`] = `
                   type="button"
                 >
                   <i
-                    className="far fa-trash"
+                    className="fas fa-trash-alt"
                   />
                    Remove
                 </button>
@@ -67,7 +67,7 @@ exports[`<Bookmarks /> should match the snapshot 1`] = `
                   type="button"
                 >
                   <i
-                    className="far fa-trash"
+                    className="fas fa-trash-alt"
                   />
                    Remove
                 </button>

--- a/src/apps/Navigation/Links.js
+++ b/src/apps/Navigation/Links.js
@@ -76,7 +76,7 @@ export const HomeLinks = () => {
           <DropDownItem classnameOuter="dropdown-item" classname="fas fa-sign-out-alt" link="/" label="Logout" />
         </ul>
       </li>
-      <NavButton classnameOuter="nav-link" classname="btn btn-success btn-sm fas fa-plus-square" link="/a/new_article" label="&nbsp;Add Post" />
+      <NavButton classnameOuter="nav-link" classname="btn btn-success btn-sm fas fa-plus-square" link="/a/createarticle" label="&nbsp;Add Post" />
     </React.Fragment>
   );
 };
@@ -88,7 +88,7 @@ export const HomeLinksSm = () => (
         <i className="fas fa-align-right" />
       </button>
       <ul className="dropdown-menu" aria-labelledby="navbarDropdown">
-        <DropDownItem classnameOuter="dropdown-item" classname="fas fa-plus-square" link="/a/new_article" label="Add Post" />
+        <DropDownItem classnameOuter="dropdown-item" classname="fas fa-plus-square" link="/a/createarticle" label="Add Post" />
         <DropDownItem classnameOuter="dropdown-item" classname="fas fa-plus-square" link="javascript:;" data-toggle="modal" data-target="#search" label="Search" />
         <li>
           <a href="/a/notifications" className="dropdown-item">

--- a/src/apps/Navigation/Routes.js
+++ b/src/apps/Navigation/Routes.js
@@ -29,7 +29,7 @@ const Main = () => (
     <Route exact path="/reset_code/:reset_code" component={ResetCodePage} />
     <Route exact path="/a/profile" component={Profile} />
     <Route exact path="/a/profile/edit" component={EditProfile} />
-    <Route exact path="/a/new_article" component={ArticlePage} />
+    <Route exact path="/a/createarticle" component={ArticlePage} />
     <Route path="/a/view_article/:slug" component={ReadArticle} />
     <Route path="/a/edit_article/:slug" component={EditArticle} />
     <Route exact path="/a/rating" component={Rating} />

--- a/src/apps/Notifiications/components/NotificationItem.js
+++ b/src/apps/Notifiications/components/NotificationItem.js
@@ -45,7 +45,9 @@ class NotificationItem extends React.Component {
         slug = slug.replace("/", "");
         return "/a/article/" + slug;
       case "object":
-        if (notification.action_object.hasOwnProperty("follower")) {
+      if (notification.action_object == null){
+        return '/a/followers';
+      } else if (notification.action_object.hasOwnProperty("follower")) {
           return '/a/followers';
         }
     }

--- a/src/apps/SocialLogin/components/SocialAuth.js
+++ b/src/apps/SocialLogin/components/SocialAuth.js
@@ -7,7 +7,7 @@ import { bake_cookie } from 'sfcookies';
 import {
   connect
 } from 'react-redux';
-
+import {redirectUrl} from '../../Articles/actions/common/common';
 import * as SocialFunc from '../actions/SocialActions';
 
 import {
@@ -93,13 +93,10 @@ class SocialAuthActions extends Component {
       })
       .then((response) => {
         passedData.receivedUsers(response.data);
-        let userData = passedData.socialAuth.userDetails;
         let token = response.data.social_token;
-        let message = `Thank you ${userData.name} for registering with us`;
-        toast.success(`🦄 ${message}`, { position: toast.POSITION.TOP_RIGHT, autoClose: 2000 });
         token = token.replace("Token","").trim();
         bake_cookie("token", token);// Set cookie
-        setTimeout(function(){window.location.replace('/home');}, 2500);
+        redirectUrl('/a/home');
       })
       .catch((err) => {
         passedData.failedCall(err);

--- a/src/apps/UserProfile/components/__snapshots__/profileComponents.test.js.snap
+++ b/src/apps/UserProfile/components/__snapshots__/profileComponents.test.js.snap
@@ -24,7 +24,7 @@ exports[`Edit Profile component should match the snapshot 1`] = `
           "entries": Array [
             Object {
               "hash": "",
-              "key": "qe36v7",
+              "key": "pk826d",
               "pathname": "/",
               "search": "",
               "state": undefined,
@@ -38,7 +38,7 @@ exports[`Edit Profile component should match the snapshot 1`] = `
           "listen": [Function],
           "location": Object {
             "hash": "",
-            "key": "qe36v7",
+            "key": "pk826d",
             "pathname": "/",
             "search": "",
             "state": undefined,


### PR DESCRIPTION
#### What does this PR do?
(UX Improvement)
- redirect users to the home page after login
- redirect users to article view after new article creation
- redirects users to article view after article updated
- redirects users to home after article deleted
- refactor new post link
- refactor social authentication link

#### Description of Task to be completed?
Once an action has been performed the user should be redirected to the necessary pages and notified of the change.

A user can only update their specific articles. The buttons to interact with other users articles have to be hidden from view

#### How should this be manually tested?
- git clone the repo to your local environment
`git clone https://github.com/andela/ah-jumanji-frontend.git` 
- checkout to the ft-users_redirection-163518461 branch
`git checkout ft-users_redirection-163518461`
- `npm install` to add all dependencies
- npm start to start the server
login add navigate to home.
`You can add a post`
`edit a post` 

#### Any background context you want to provide?
Redirection shows the user that an action has been performed. It is vital for a good user experience

#### What are the relevant pivotal tracker stories?

#### Screenshots (if appropriate)
--
#### Questions:
--
#### Checklist:

- [x] My code follows the style guidelines of this project
- [ ] At least 2 people have reviewed my PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My PR has one commit.
